### PR TITLE
Update deps and enforce EOF newline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,22 +22,22 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.2.1</version>
+      <version>3.9.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.2.1</version>
+      <version>3.9.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.enforcer</groupId>
       <artifactId>enforcer-api</artifactId>
-      <version>1.3.1</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
-      <version>1.5.5</version>
+      <version>2.1.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/resources/checkstyle/checkstyle-checker.xml
+++ b/src/main/resources/checkstyle/checkstyle-checker.xml
@@ -339,11 +339,11 @@
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
   </module>
-  <!--module name="NewlineAtEndOfFile">
+  <module name="NewlineAtEndOfFile">
     <property name="severity" value="error"/>
     <property name="lineSeparator" value="system"/>
     <property name="fileExtensions" value="java, xml, txt, properties"/>
-  </module-->
+  </module>
   <module name="Translation">
     <property name="severity" value="error"/>
     <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>


### PR DESCRIPTION
## Summary
- update Maven dependencies to newer versions
- enable `NewlineAtEndOfFile` rule in Checkstyle

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684853e13e84832e91532f54a17b277c